### PR TITLE
Refact

### DIFF
--- a/lua/telekasten.lua
+++ b/lua/telekasten.lua
@@ -2945,6 +2945,7 @@ local TelekastenCmd = {
     end,
 }
 
+---@param subcommand string
 TelekastenCmd.command = function(subcommand)
     local show = function(opts)
         opts = opts or {}
@@ -2979,15 +2980,15 @@ TelekastenCmd.command = function(subcommand)
             :find()
     end
     if subcommand then
-        -- print("trying subcommand " .. "`" .. subcommand .. "`")
+        local trimmed_subcommand = string.gsub(subcommand, "^%s*(.-)%s*$", "%1")
         for _, entry in pairs(TelekastenCmd.commands()) do
-            if entry[2] == subcommand then
+            if entry[2] == trimmed_subcommand then
                 local selection = entry[3]
                 selection()
                 return
             end
         end
-        print("No such subcommand: `" .. subcommand .. "`")
+        print("No such subcommand: `" .. trimmed_subcommand .. "`")
     else
         local theme
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
  Please note: we want to avoid breaking changes at all cost
-->

## Type of change

<!--
  What type of change does your PR introduce to Telekasten?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (thank you!)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation update

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] I am running the **latest** version of the plugin.
- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Stylua (a `.stylua.toml` file is provided)
- [ ] The code has been checked with luacheck (a `.luacheckrc` file is provided)
- [ ] The `README.md` has been updated according to this change.
- [ ] The `doc/telekasten.txt` helpfile has been updated according to this change.

<!--
  Thank you for contributing <3
-->
